### PR TITLE
Fitur: Tambahkan Skrip Otomatisasi VPN WireGuard

### DIFF
--- a/vpn/README.md
+++ b/vpn/README.md
@@ -1,0 +1,92 @@
+# Skrip Instalasi & Manajemen VPN WireGuard
+
+Proyek ini menyediakan dua skrip Bash untuk mempermudah proses pembuatan dan pengelolaan server VPN WireGuard pribadi Anda di server berbasis Debian atau Ubuntu.
+
+-   `install_vpn.sh`: Menginstal WireGuard, membuat semua konfigurasi awal, dan menghasilkan file konfigurasi untuk klien pertama.
+-   `add_user.sh`: Menambahkan pengguna (klien) baru ke server VPN yang sudah ada.
+
+## Persyaratan
+
+-   Sebuah server yang menjalankan sistem operasi Debian atau Ubuntu.
+-   Akses root atau pengguna dengan hak `sudo` di server tersebut.
+
+---
+
+## Panduan Penggunaan
+
+### Langkah 1: Instalasi Awal Server VPN
+
+Proses ini hanya perlu dilakukan sekali saat pertama kali menyiapkan server.
+
+1.  **Salin Skrip ke Server Anda**
+    Salin file `install_vpn.sh` dan `add_user.sh` ke direktori home di server Anda. Anda bisa melakukannya dengan `scp` atau dengan menyalin dan menempelkan isinya menggunakan editor teks seperti `nano`.
+
+2.  **Berikan Izin Eksekusi**
+    Buka terminal di server Anda dan berikan izin agar skrip dapat dijalankan:
+    ```bash
+    chmod +x install_vpn.sh add_user.sh
+    ```
+
+3.  **Jalankan Skrip Instalasi**
+    Jalankan skrip instalasi dengan hak `sudo`. Skrip ini akan menginstal semua yang dibutuhkan, membuat kunci, dan mengkonfigurasi server.
+    ```bash
+    sudo ./install_vpn.sh
+    ```
+    Ikuti instruksi yang mungkin muncul. Setelah selesai, skrip akan membuat file bernama `client.conf` di direktori yang sama.
+
+4.  **Ambil File Konfigurasi Klien**
+    File `client.conf` adalah "tiket" Anda untuk terhubung ke VPN. Salin file ini dari server ke perangkat Anda (HP atau laptop). Anda bisa menggunakan `scp` atau menampilkan isinya dengan `cat client.conf` lalu menyalin teksnya secara manual.
+
+### Langkah 2: Menghubungkan Klien (Perangkat Anda)
+
+1.  **Instal Aplikasi WireGuard**
+    Unduh dan instal aplikasi resmi WireGuard di perangkat Anda.
+    -   [Android](https://play.google.com/store/apps/details?id=com.wireguard.android)
+    -   [iOS (iPhone/iPad)](https://apps.apple.com/us/app/wireguard/id1441195209)
+    -   [Windows](https://download.wireguard.com/windows-client/wireguard-installer.exe)
+    -   [macOS](https://apps.apple.com/us/app/wireguard/id1451685025)
+
+2.  **Impor Konfigurasi**
+    Buka aplikasi WireGuard dan impor file `client.conf` yang sudah Anda salin. Biasanya ada tombol `+` atau "Import tunnel(s) from file". Anda juga bisa menggunakan fitur pindai kode QR jika aplikasi menawarkannya (skrip ini tidak membuat kode QR).
+
+3.  **Aktifkan Koneksi**
+    Setelah profil diimpor, cukup tekan tombol *connect* atau *activate* untuk terhubung ke server VPN Anda.
+
+---
+
+### Langkah 3: Menambah Pengguna atau Perangkat Baru
+
+Jika Anda ingin menghubungkan perangkat lain (misalnya, laptop setelah HP Anda terhubung), jalankan skrip `add_user.sh`.
+
+1.  **Jalankan Skrip `add_user.sh`**
+    Di server Anda, jalankan perintah:
+    ```bash
+    sudo ./add_user.sh
+    ```
+
+2.  **Masukkan Nama Klien**
+    Skrip akan meminta Anda memasukkan nama untuk klien baru. Gunakan nama yang deskriptif tanpa spasi, contoh: `laptop_kerja` atau `hp_samsung`.
+
+3.  **Ambil File Konfigurasi Baru**
+    Skrip akan membuat file baru, contohnya `laptop_kerja.conf`. Sama seperti sebelumnya, salin file ini ke perangkat baru Anda dan impor ke aplikasi WireGuard di sana.
+
+    Ulangi langkah ini setiap kali Anda ingin menambahkan perangkat baru.
+
+---
+
+## Perintah Server yang Berguna
+
+-   **Melihat Status WireGuard dan Klien yang Terhubung:**
+    ```bash
+    sudo wg show
+    ```
+
+-   **Memulai Ulang Layanan WireGuard:**
+    ```bash
+    sudo systemctl restart wg-quick@wg0
+    ```
+
+-   **Melihat Log Layanan:**
+    ```bash
+    sudo journalctl -u wg-quick@wg0
+    ```

--- a/vpn/add_user.sh
+++ b/vpn/add_user.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Pastikan skrip dijalankan sebagai root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Skrip ini harus dijalankan sebagai root. Coba jalankan dengan 'sudo'." >&2
+  exit 1
+fi
+
+# Pastikan file konfigurasi server ada
+if [ ! -f /etc/wireguard/wg0.conf ]; then
+    echo "Kesalahan: File konfigurasi server /etc/wireguard/wg0.conf tidak ditemukan."
+    echo "Pastikan Anda telah menjalankan skrip instalasi terlebih dahulu."
+    exit 1
+fi
+
+# Minta nama untuk klien baru
+read -p "Masukkan nama untuk klien VPN baru (contoh: hp_budi, laptop_kantor): " CLIENT_NAME
+
+# Validasi input nama klien
+if [ -z "$CLIENT_NAME" ]; then
+    echo "Kesalahan: Nama klien tidak boleh kosong."
+    exit 1
+fi
+# Hapus spasi dan karakter spesial untuk nama file yang aman
+SAFE_CLIENT_NAME=$(echo "$CLIENT_NAME" | tr -dc 'a-zA-Z0-9_-')
+
+# --- Logika Penentuan IP ---
+# Temukan IP terakhir yang digunakan di wg0.conf
+LAST_IP=$(grep 'AllowedIPs' /etc/wireguard/wg0.conf | tail -n 1 | awk -F '[ ./]' '{print $6}')
+# Jika tidak ada IP sebelumnya, mulai dari 2
+if [ -z "$LAST_IP" ]; then
+    # Jika server (10.0.0.1) adalah satu-satunya entri, IP klien pertama adalah 2
+    LAST_IP=1
+fi
+
+# IP baru adalah IP terakhir + 1
+NEW_IP_OCTET=$((LAST_IP + 1))
+CLIENT_PRIVATE_IP="10.0.0.${NEW_IP_OCTET}/32"
+
+echo "INFO: IP internal berikutnya yang tersedia adalah 10.0.0.${NEW_IP_OCTET}"
+
+# --- Pembuatan Kunci Klien ---
+echo "INFO: Membuat kunci privat dan publik untuk klien '${SAFE_CLIENT_NAME}'..."
+CLIENT_PRIVATE_KEY=$(wg genkey)
+CLIENT_PUBLIC_KEY=$(echo "${CLIENT_PRIVATE_KEY}" | wg pubkey)
+
+# --- Pembuatan Konfigurasi Klien ---
+SERVER_PUBLIC_KEY=$(cat /etc/wireguard/server_public.key)
+SERVER_PUBLIC_IP=$(curl -s https://api.ipify.org)
+SERVER_PORT=$(grep 'ListenPort' /etc/wireguard/wg0.conf | awk '{print $3}')
+
+if [ -z "${SERVER_PUBLIC_IP}" ]; then
+    echo "PERINGATAN: Tidak dapat mendeteksi IP publik server secara otomatis."
+    SERVER_PUBLIC_IP="[SERVER_IP_PUBLIK]"
+fi
+
+# Buat file konfigurasi di direktori saat ini
+CLIENT_CONFIG_FILE="${SAFE_CLIENT_NAME}.conf"
+echo "INFO: Membuat file konfigurasi klien (${CLIENT_CONFIG_FILE})..."
+cat > ./${CLIENT_CONFIG_FILE} << EOL
+[Interface]
+PrivateKey = ${CLIENT_PRIVATE_KEY}
+Address = ${CLIENT_PRIVATE_IP}
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = ${SERVER_PUBLIC_KEY}
+Endpoint = ${SERVER_PUBLIC_IP}:${SERVER_PORT}
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+EOL
+
+# --- Tambahkan Klien ke Server ---
+echo "INFO: Menambahkan klien baru ke konfigurasi server..."
+cat >> /etc/wireguard/wg0.conf << EOL
+
+[Peer]
+# Klien: ${CLIENT_NAME}
+PublicKey = ${CLIENT_PUBLIC_KEY}
+AllowedIPs = ${CLIENT_PRIVATE_IP}
+EOL
+
+# --- Terapkan Perubahan ---
+echo "INFO: Menerapkan konfigurasi baru ke WireGuard..."
+wg syncconf wg0 <(wg-quick strip wg0)
+
+# --- Selesai ---
+echo ""
+echo "=========================================================="
+echo "          ✅ Klien VPN Baru Berhasil Ditambahkan! ✅"
+echo "=========================================================="
+echo ""
+echo "-> Nama Klien: ${CLIENT_NAME}"
+echo "-> Konfigurasi klien telah disimpan di ./${CLIENT_CONFIG_FILE}"
+echo ""
+echo "Langkah Selanjutnya:"
+echo "1. Salin file '${CLIENT_CONFIG_FILE}' ke perangkat baru."
+echo "2. Impor file tersebut ke aplikasi WireGuard di perangkat itu."
+echo "3. Hubungkan VPN!"
+echo ""
+echo "Status VPN saat ini:"
+wg show
+echo "=========================================================="

--- a/vpn/install_vpn.sh
+++ b/vpn/install_vpn.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Pastikan skrip dijalankan sebagai root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Skrip ini harus dijalankan sebagai root. Coba jalankan dengan 'sudo'." >&2
+  exit 1
+fi
+
+# --- Variabel (dapat disesuaikan) ---
+# Ganti dengan nama network interface utama Anda jika berbeda (misal: eth0, ens3)
+# Gunakan `ip a` atau `ifconfig` untuk memeriksa
+SERVER_INTERFACE="eth0"
+# Ganti dengan port yang Anda inginkan
+SERVER_PORT=51820
+# Alamat IP internal untuk server VPN
+SERVER_PRIVATE_IP="10.0.0.1/24"
+# Alamat IP internal untuk klien pertama
+CLIENT_PRIVATE_IP="10.0.0.2/32"
+
+# --- Instalasi ---
+echo "INFO: Memperbarui daftar paket..."
+apt-get update
+
+echo "INFO: Menginstal WireGuard dan paket pendukung..."
+apt-get install -y wireguard resolvconf
+
+# --- Pembuatan Kunci ---
+echo "INFO: Membuat kunci server dan klien..."
+# Buat direktori konfigurasi
+mkdir -p /etc/wireguard
+# Atur izin yang aman
+chmod 700 /etc/wireguard
+
+# Hapus kunci lama jika ada untuk menghindari konflik
+rm -f /etc/wireguard/server_private.key /etc/wireguard/server_public.key
+rm -f /etc/wireguard/client_private.key /etc/wireguard/client_public.key
+
+# Buat kunci baru
+wg genkey | tee /etc/wireguard/server_private.key | wg pubkey > /etc/wireguard/server_public.key
+wg genkey | tee /etc/wireguard/client_private.key | wg pubkey > /etc/wireguard/client_public.key
+
+# Simpan nilai kunci ke dalam variabel
+SERVER_PRIVATE_KEY=$(cat /etc/wireguard/server_private.key)
+SERVER_PUBLIC_KEY=$(cat /etc/wireguard/server_public.key)
+CLIENT_PRIVATE_KEY=$(cat /etc/wireguard/client_private.key)
+CLIENT_PUBLIC_KEY=$(cat /etc/wireguard/client_public.key)
+
+# --- Konfigurasi Server ---
+echo "INFO: Membuat file konfigurasi server (/etc/wireguard/wg0.conf)..."
+cat > /etc/wireguard/wg0.conf << EOL
+[Interface]
+Address = ${SERVER_PRIVATE_IP}
+PrivateKey = ${SERVER_PRIVATE_KEY}
+ListenPort = ${SERVER_PORT}
+PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -t nat -A POSTROUTING -o ${SERVER_INTERFACE} -j MASQUERADE
+PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -t nat -D POSTROUTING -o ${SERVER_INTERFACE} -j MASQUERADE
+
+[Peer]
+# Klien 1
+PublicKey = ${CLIENT_PUBLIC_KEY}
+AllowedIPs = ${CLIENT_PRIVATE_IP}
+EOL
+
+# --- Konfigurasi Klien ---
+# Dapatkan alamat IP publik server
+SERVER_PUBLIC_IP=$(curl -s https://api.ipify.org)
+if [ -z "${SERVER_PUBLIC_IP}" ]; then
+    echo "PERINGATAN: Tidak dapat mendeteksi IP publik secara otomatis."
+    echo "Harap edit 'client.conf' dan ganti '[SERVER_IP_PUBLIK]' secara manual."
+    SERVER_PUBLIC_IP="[SERVER_IP_PUBLIK]"
+fi
+
+echo "INFO: Membuat file konfigurasi klien (client.conf)..."
+cat > ./client.conf << EOL
+[Interface]
+PrivateKey = ${CLIENT_PRIVATE_KEY}
+Address = ${CLIENT_PRIVATE_IP}
+DNS = 1.1.1.1 # DNS resolver dari Cloudflare
+
+[Peer]
+PublicKey = ${SERVER_PUBLIC_KEY}
+Endpoint = ${SERVER_PUBLIC_IP}:${SERVER_PORT}
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+EOL
+
+# --- Aktifkan IP Forwarding ---
+echo "INFO: Mengaktifkan IP forwarding..."
+sed -i '/net.ipv4.ip_forward=1/s/^#//' /etc/sysctl.conf
+sysctl -p
+
+# --- Mulai Layanan WireGuard ---
+echo "INFO: Memulai dan mengaktifkan layanan WireGuard (wg-quick@wg0)..."
+systemctl enable wg-quick@wg0
+systemctl start wg-quick@wg0
+
+# --- Selesai ---
+echo ""
+echo "=========================================================="
+echo "          🎉 Instalasi VPN WireGuard Selesai! 🎉"
+echo "=========================================================="
+echo ""
+echo "-> Konfigurasi server telah disimpan di /etc/wireguard/wg0.conf"
+echo "-> Konfigurasi klien telah disimpan di ./client.conf"
+echo ""
+echo "Langkah Selanjutnya:"
+echo "1. Salin file 'client.conf' ke perangkat Anda (HP/PC)."
+echo "2. Instal aplikasi WireGuard di perangkat Anda."
+echo "3. Impor file 'client.conf' ke dalam aplikasi."
+echo "4. Hubungkan VPN!"
+echo ""
+echo "Untuk memeriksa status VPN di server, gunakan perintah: wg show"
+echo "=========================================================="


### PR DESCRIPTION
Menambahkan satu set skrip Bash untuk secara otomatis menginstal, mengkonfigurasi, dan mengelola server VPN WireGuard.

- `vpn/install_vpn.sh`: Skrip untuk instalasi awal server.
- `vpn/add_user.sh`: Skrip untuk menambahkan klien/pengguna baru dengan mudah.
- `vpn/README.md`: Dokumentasi lengkap tentang cara menggunakan skrip ini.

Skrip ini ditempatkan di dalam direktori `vpn` baru agar tidak mengganggu proyek bot Telegram yang ada.