### PR TITLE
Feat: Implement 24/7 Termux mode with wake lock integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ Bot Telegram serbaguna yang dirancang untuk berjalan di Termux, mampu mengunduh 
 -   **Indikator Memuat**: Umpan balik visual dengan stiker animasi selama proses unduhan.
 -   **Instalasi Mudah**: Skrip penyiapan interaktif untuk konfigurasi token yang mudah.
 -   **Notifikasi Status**: Menerima siaran saat bot online atau offline.
+-   **Mode 24/7 di Termux**: Terintegrasi dengan `termux-wake-lock` untuk mencegah bot dimatikan oleh sistem Android.
 
 ## Prasyarat
 
 -   **Python**: `pkg install python`
 -   **FFmpeg**: `pkg install ffmpeg`
 -   **Git**: `pkg install git`
+-   **Termux API (untuk mode 24/7)**: `pkg install termux-api`
+
+## Menjalankan di Termux (Mode 24/7)
+
+Bot ini dirancang untuk berjalan terus-menerus di Termux. Skrip `start.sh` secara otomatis menggunakan `termux-wake-lock` untuk mencegah Android mematikan bot untuk menghemat baterai. Demikian pula, `stop.sh` akan melepaskan kunci tersebut.
+
+Pastikan aplikasi Termux:API sudah terinstal dari F-Droid dan Anda telah menjalankan `pkg install termux-api` agar fitur ini berfungsi.
 
 ## Penyiapan Cepat
 

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,8 @@ if [ -f $PID_FILE ]; then
 fi
 
 echo "Memulai bot di latar belakang..."
+echo "Mengaktifkan Termux wake lock untuk mencegah bot mati..."
+termux-wake-lock &
 
 # Jalankan bot menggunakan nohup, arahkan output ke log
 nohup python3 bot.py > $LOG_FILE 2>&1 &

--- a/stop.sh
+++ b/stop.sh
@@ -28,3 +28,7 @@ fi
 rm -f $PID_FILE
 
 echo "Pembersihan selesai. File log tetap ada di $LOG_FILE."
+
+# Selalu coba lepaskan wake lock untuk memastikan kebersihan
+echo "Melepaskan Termux wake lock..."
+termux-wake-unlock


### PR DESCRIPTION
This commit introduces a critical feature for users running the bot on Termux: a true 24/7 nonstop operational mode. This is achieved by integrating with Termux's power management APIs to prevent the Android OS from killing the bot process.

**Key Changes:**

1.  **`termux-wake-lock` Integration:**
    *   The `start.sh` script has been modified to automatically run `termux-wake-lock &` in the background when the bot is started. This acquires a wake lock, signaling to the Android system that the Termux session is performing important work and should not be terminated to save power.

2.  **`termux-wake-unlock` Integration:**
    *   The `stop.sh` script has been updated to automatically run `termux-wake-unlock` upon execution. This cleanly releases the wake lock, allowing the Android system to resume normal power management once the bot is no longer needed.

3.  **Comprehensive Documentation:**
    *   The `README.md` file has been significantly updated with a new "Running on Termux (24/7)" section.
    *   It now clearly explains the purpose of the wake lock feature and adds `pkg install termux-api` to the list of prerequisites, ensuring users can set up this functionality correctly.

This overhaul directly addresses the user's request for a nonstop mode, transforming the bot into a reliable, 24/7 service on the Termux platform while maintaining a clean startup and shutdown process that avoids ghost processes.