### PR TITLE
fix: Definitive fixes for sticker and video conversion errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -190,7 +190,7 @@ async def handle_search_download(update: Update, context: CallbackContext) -> No
     logger.info(f"-> SEARCH_DL: Parsed callback. Format: {format_choice}, Video ID: {video_id}")
     await query.edit_message_reply_markup(reply_markup=None)
     logger.info("-> SEARCH_DL: Removed inline keyboard.")
-    sticker_message = await query.message.reply_sticker("CAACAgIAAxkBAAIEv2X0x4-v2-5v3e_wY_v2-5v3e_wYAAJ-BwAC-5-xS_v2-5v3e_wYHgQ")
+    status_message = await query.message.reply_text("⏳ Memproses permintaan Anda...")
     try:
         logger.info(f"-> SEARCH_DL: Calling download_file for Video ID: {video_id}")
         await download_file(video_id, format_choice, update, context)
@@ -199,9 +199,9 @@ async def handle_search_download(update: Update, context: CallbackContext) -> No
         logger.error(f"-> SEARCH_DL: Error during download_file call from search: {e}", exc_info=True)
         await query.message.reply_text("❌ Gagal mengunduh file dari hasil pencarian.")
     finally:
-        if sticker_message:
-            await sticker_message.delete()
-            logger.info("-> SEARCH_DL: Deleted sticker message.")
+        if status_message:
+            await status_message.delete()
+            logger.info("-> SEARCH_DL: Deleted status message.")
 
 async def handle_url_download(update: Update, context: CallbackContext) -> None:
     """Handles download callbacks from a submitted URL (using a UUID key)."""
@@ -226,7 +226,7 @@ async def handle_url_download(update: Update, context: CallbackContext) -> None:
     logger.info(f"-> URL_DL: Retrieved URL '{url}' from user_data.")
     await query.edit_message_reply_markup(reply_markup=None)
     logger.info("-> URL_DL: Removed inline keyboard.")
-    sticker_message = await query.message.reply_sticker("CAACAgIAAxkBAAIEv2X0x4-v2-5v3e_wY_v2-5v3e_wYAAJ-BwAC-5-xS_v2-5v3e_wYHgQ")
+    status_message = await query.message.reply_text("⏳ Memproses permintaan Anda...")
     try:
         logger.info(f"-> URL_DL: Calling download_file for URL key: {url_key}")
         await download_file(url, format_choice, update, context)
@@ -235,9 +235,9 @@ async def handle_url_download(update: Update, context: CallbackContext) -> None:
         logger.error(f"-> URL_DL: Error during download_file call from URL: {e}", exc_info=True)
         await query.message.reply_text("❌ Gagal mengunduh file dari URL.")
     finally:
-        if sticker_message:
-            await sticker_message.delete()
-            logger.info("-> URL_DL: Deleted sticker message.")
+        if status_message:
+            await status_message.delete()
+            logger.info("-> URL_DL: Deleted status message.")
 
 async def download_file(identifier: str, format_choice: str, update: Update, context: CallbackContext):
     logger.info(f"-> DOWNLOAD_FILE: Starting process for identifier: {identifier}, format: {format_choice}")
@@ -353,7 +353,13 @@ async def get_video(update: Update, context: CallbackContext) -> int:
     video_file = await video_file_obj.get_file()
     download_dir = 'downloads'
     os.makedirs(download_dir, exist_ok=True)
+
+    # Menangani video tanpa nama file asli (misalnya, dari Telegram mobile)
     original_filename = video_file_obj.file_name
+    if not original_filename:
+        logger.warning("-> CONVERT_VIDEO: Video does not have an original filename. Assigning a default name.")
+        original_filename = f"video_{uuid.uuid4()}.mp4"
+
     video_path = os.path.join(download_dir, f"{uuid.uuid4()}_{original_filename}")
 
     logger.info(f"-> CONVERT_VIDEO: Downloading video to {video_path}...")

--- a/video_converter.py
+++ b/video_converter.py
@@ -18,8 +18,11 @@ def convert_video_resolution(input_path: str, target_resolution: str) -> str:
     if not os.path.exists(input_path):
         raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    filename = os.path.basename(input_path)
-    output_path = f"converted_{target_resolution}_{filename}"
+    # Pastikan file output selalu punya ekstensi .mp4
+    base_filename, _ = os.path.splitext(os.path.basename(input_path))
+    output_filename = f"converted_{target_resolution}_{base_filename}.mp4"
+    # Tempatkan file output di direktori yang sama dengan input
+    output_path = os.path.join(os.path.dirname(input_path), output_filename)
 
     # Map friendly names to ffmpeg scale parameters
     # -2 ensures the width is divisible by 2, which is required by many codecs.


### PR DESCRIPTION
This commit provides definitive fixes for the two critical bugs identified from the user-provided logs.

1.  **Fix Sticker Error:** The `BadRequest` error during downloads is resolved by completely removing the sticker-sending logic, which relied on an invalid, hardcoded file ID. It is replaced with a reliable text-based status message (`⏳ Memproses permintaan Anda...`). This affects both `handle_search_download` and `handle_url_download`.

2.  **Fix Video Conversion Error:** The `ffmpeg` failure is resolved by ensuring video files always have a valid filename with an extension.
    - `bot.py` is updated to assign a default `.mp4` filename to any incoming video that lacks one.
    - `video_converter.py` is updated to ensure the output file always has a `.mp4` extension, fixing the `Invalid argument` error from `ffmpeg`.

These changes directly address the root causes of the crashes and ensure the download and video conversion features are now fully functional and robust.