### PR TITLE
hotfix(filters): Correct syntax for Document filter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -582,7 +582,7 @@ def main() -> None:
     convert_conv = ConversationHandler(
         entry_points=[CommandHandler("convert_video", convert_video_start)],
         states={
-            GET_VIDEO: [MessageHandler(filters.VIDEO | filters.Document, get_video)],
+            GET_VIDEO: [MessageHandler(filters.VIDEO | filters.Document(), get_video)],
             GET_RESOLUTION: [CallbackQueryHandler(apply_conversion, pattern="^convert:")],
         },
         fallbacks=[CommandHandler("cancel", cancel)],


### PR DESCRIPTION
This commit fixes a critical startup crash caused by an `AttributeError`.

- The `MessageHandler` for the `/convert_video` command was using the incorrect syntax `filters.Document`, which is a class name, instead of the required instance `filters.Document()`.
- The filter has been corrected to `filters.VIDEO | filters.Document()`.

This resolves the fatal `AttributeError: type object 'Document' has no attribute 'data_filter'` and allows the bot to start correctly.