### PR TITLE
Fix Search Command by Removing Timestamp and Correcting Error Message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -149,10 +149,9 @@ async def search_get_query(update: Update, context: CallbackContext):
             'noplaylist': True,
             'match_filter': 'duration < 1800'
         }
-        search_query = f"{update.message.text} {int(time.time())}"
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl: result = ydl.extract_info(search_query, download=False)
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl: result = ydl.extract_info(update.message.text, download=False)
         if not result.get('entries'):
-            await update.message.reply_text("Tidak ada hasil yang cocok dengan filter regional.")
+            await update.message.reply_text("Tidak ada hasil yang cocok dengan filter durasi (di bawah 30 menit).")
             return ConversationHandler.END
 
         for entry in result['entries'][:5]:


### PR DESCRIPTION
This commit provides a definitive fix for the `/search` command, which was failing for certain queries.

- Removes the timestamp addition from the search query. This was conflicting with the duration filter and causing YouTube to return no results.
- Corrects the user-facing error message to accurately reflect that the failure is due to the duration filter, not a non-existent regional filter.

This change strictly adheres to the user's request to only fix the error without altering the bot's existing structure or workflow.