### PR TITLE
fix(search): Atasi crash saat memformat durasi

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -166,7 +166,8 @@ async def _display_search_page(update: Update, context: CallbackContext, is_edit
 
     for i, entry in enumerate(page_results):
         num = i + 1
-        duration = f"{(entry.get('duration', 0) // 60):02d}:{(entry.get('duration', 0) % 60):02d}"
+        duration_seconds = int(entry.get('duration', 0))
+        duration = f"{(duration_seconds // 60):02d}:{(duration_seconds % 60):02d}"
         message_text += f"{num}. ({duration}) `{entry['title']}`\n\n"
         row.append(InlineKeyboardButton(str(num), callback_data=f"search:select:{start_index + i}"))
         if len(row) == 5:


### PR DESCRIPTION
Memperbaiki `ValueError` yang terjadi saat perintah `/search` mencoba memformat durasi video. Bug ini disebabkan oleh nilai durasi yang berupa float, sementara kode mencoba memformatnya sebagai integer, yang mengakibatkan crash sebelum daftar hasil dapat dikirim ke pengguna.

Perbaikan ini memastikan bahwa nilai durasi secara eksplisit diubah menjadi integer sebelum diformat, sehingga menyelesaikan crash dan memungkinkan fungsionalitas pencarian bekerja sesuai harapan.