### PR TITLE
Fix: Handle Float Duration to Prevent ValueError Crash

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -196,7 +196,8 @@ async def _display_search_page(update: Update, context: CallbackContext, query: 
         keyboard_buttons, row = [], []
         for i, entry in enumerate(page_results):
             num_on_page = i + 1
-            duration = f"{(int(entry.get('duration', 0)) // 60):02d}:{(int(entry.get('duration', 0)) % 60):02d}"
+            duration_in_seconds = int(entry.get('duration', 0))
+            duration = f"{(duration_in_seconds // 60):02d}:{(duration_in_seconds % 60):02d}"
             safe_title = escape_markdown(entry.get('title', 'Tanpa Judul'), version=2)
             message_text += f"{num_on_page}. ({duration}) *{safe_title}*\n\n"
             row.append(InlineKeyboardButton(str(num_on_page), callback_data=f"search:select:{entry['id']}:{page}"))
@@ -321,7 +322,7 @@ async def song_get_title(update: Update, context: CallbackContext):
             video_info = result.get('entries', [result])[0]
 
             # --- Filter Durasi Manual ---
-            duration = video_info.get('duration', 9999)
+            duration = int(video_info.get('duration', 9999))
             if duration > 600:
                 await status_message.edit_text("❌ Gagal: Lagu ditemukan, tetapi durasinya lebih dari 10 menit.")
                 return ConversationHandler.END


### PR DESCRIPTION
This commit resolves a `ValueError: Unknown format code 'd' for object of type 'float'` that would crash the bot, particularly in the `/search` and `/song` commands.

The root cause was that `yt-dlp` can return a video's duration as a float (e.g., `123.45`), but the string formatting logic expected an integer to correctly display it in a `MM:SS` format.

The fix is to explicitly cast the duration value to an `int` before performing any string formatting or calculations. This has been applied in all relevant functions (`_display_search_page` and `song_get_title`) to ensure the bot can handle both integer and float duration values gracefully without crashing.